### PR TITLE
Fix Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REVISION ?= testing-$(USER)
 DOCKER_TAG = docker-push.ocf.berkeley.edu/ocfapi:$(DOCKER_REVISION)
-HOST=127.0.0.1
-PORT=8000
+HOST = 127.0.0.1
+PORT = 8000
 
 .PHONY: cook-image
 cook-image:
@@ -11,30 +11,30 @@ cook-image:
 push-image:
 	docker push $(DOCKER_TAG)
 
-venv: requirements.txt requirements-dev.txt
+venv: | venv/pyvenv.cfg
+
+venv/pyvenv.cfg: requirements.txt requirements-dev.txt
 	python3 -m venv venv && \
 	. venv/bin/activate && \
 	pip install --upgrade "pip>=20.3" && \
-	pip install -r requirements.txt -r requirements-dev.txt
+	pip install -r requirements.txt -r requirements-dev.txt && \
+	pre-commit install
 
 .PHONY: dev
-dev:
-	chmod u+x venv/bin/activate && \
+dev: venv
+	@chmod u+x venv/bin/activate && \
 	. venv/bin/activate && \
 	cd app && \
 	python -m uvicorn main:app --reload --host $(HOST) --port $(PORT)
 
 .PHONY: test
-test: venv unit-test
-
-.PHONY: unit-test
-unit-test:
-	chmod u+x venv/bin/activate && \
+test: venv
+	@chmod u+x venv/bin/activate && \
 	. venv/bin/activate && \
 	cd app && \
 	python -m pytest
 
 .PHONY: update-requirements
 update-requirements: venv
-	$(BIN)/upgrade-requirements
-	sed -i 's/^ocflib==.*/ocflib/' requirements.txt
+	@venv/bin/upgrade-requirements
+	@sed -i 's/^ocflib==.*/ocflib/' requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ venv: | venv/pyvenv.cfg
 
 venv/pyvenv.cfg: requirements.txt requirements-dev.txt
 	python3 -m venv venv && \
+	chmod u+x venv/bin/activate && \
 	. venv/bin/activate && \
 	pip install --upgrade "pip>=20.3" && \
 	pip install -r requirements.txt -r requirements-dev.txt && \
@@ -22,15 +23,13 @@ venv/pyvenv.cfg: requirements.txt requirements-dev.txt
 
 .PHONY: dev
 dev: venv
-	@chmod u+x venv/bin/activate && \
-	. venv/bin/activate && \
+	@. venv/bin/activate && \
 	cd app && \
 	python -m uvicorn main:app --reload --host $(HOST) --port $(PORT)
 
 .PHONY: test
 test: venv
-	@chmod u+x venv/bin/activate && \
-	. venv/bin/activate && \
+	@. venv/bin/activate && \
 	cd app && \
 	python -m pytest
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,14 @@ An authenticated API for the OCF.
 
 # Developing locally
 
-## Setup
-
 ```
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-pre-commit install
+make dev
 ```
 
-## Running
+## Running tests
 
 ```
-python -m uvicorn app.main:app --reload
+make test
 ```
 
 # Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ importlib-metadata==4.11.2
 Jinja2==3.0.3
 ldap3==2.9.1
 MarkupSafe==2.1.0
-ocflib==2021.12.9.0.47
+ocflib
 pexpect==4.8.0
 ply==3.11
 ptyprocess==0.7.0


### PR DESCRIPTION
Properly construct the venv target so it doesn't get recreated every time you run a command. This allows us to also simplify the development experience since we only need one command to get everything setup and running (`make dev`).