### PR TITLE
Send Calnet JWT as GET param

### DIFF
--- a/app/routes/auth/calnet.py
+++ b/app/routes/auth/calnet.py
@@ -31,7 +31,7 @@ async def calnet_login_callback(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "got bad ticket")
     jwt = create_calnet_jwt(uid)
     if calnet_redirect_url:
-        response = RedirectResponse(calnet_redirect_url + "?ocfapi_calnet_token=" + jwt)
+        response = RedirectResponse(calnet_redirect_url + "#ocfapi_calnet_token=" + jwt)
         response.delete_cookie("calnet_redirect_url")
         response.set_cookie(
             "ocfapi_calnet_token",

--- a/app/routes/auth/calnet.py
+++ b/app/routes/auth/calnet.py
@@ -31,7 +31,7 @@ async def calnet_login_callback(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "got bad ticket")
     jwt = create_calnet_jwt(uid)
     if calnet_redirect_url:
-        response = RedirectResponse(calnet_redirect_url)
+        response = RedirectResponse(calnet_redirect_url + "?ocfapi_calnet_token=" + jwt)
         response.delete_cookie("calnet_redirect_url")
         response.set_cookie(
             "ocfapi_calnet_token",


### PR DESCRIPTION
After calling the `/auth/calnet` endpoint with the `next` param set, the API does not send the token on to the requester. The cookie that is set does not go to the `next` destination, but to `api.ocf.berkeley.edu` instead. By passing the JWT as a GET param to `next`, we can actually use the token when the user authenticates.